### PR TITLE
Fix issue when a group of 4 characters start with A

### DIFF
--- a/lib/Base64.pm6
+++ b/lib/Base64.pm6
@@ -61,7 +61,8 @@ multi sub decode-base64(Str $str, :$pad, :@alpha, |c --> Seq) {
         state %lookup = $encodings.kv.hash.antipairs;
         my $n   = [+] $chunk.map: { (%lookup{$_} || 0) +< ((state $m = 24) -= 6) }
         my $res = (16, 8, 0).map: { $n +> $_ +& 255 }
-        slip($res.grep(* > 0));
+        #slip($res.grep(* > 0));
+        slip($res.head( 3 - ( 4 - $chunk.elems ) ) );
     }
 }
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,7 +1,7 @@
 use Base64;
 
 use Test;
-plan 5;
+plan 6;
 
 subtest {
     is encode-base64("", :str), '', 'Encoding the empty string';
@@ -41,6 +41,10 @@ subtest {
 }, 'Decode';
 
 subtest {
+    is encode-base64( decode-base64("w0OfABDTw0Of", :buf) , :str ), "w0OfABDTw0Of", "decoded then re-encoded value equals to origianl one, with A in first position of a 4 characters group";
+}
+
+subtest {
     is encode-base64("\x14\xfb\x9c\x03\xd9\x7e", :str), "FPucA9l+";
     is encode-base64("\x14\xfb\x9c\x03\xd9", :str),     "FPucA9k=";
     is encode-base64("\x14\xfb\x9c\x03", :str),         "FPucAw==";
@@ -53,5 +57,5 @@ subtest {
 
 subtest {
     my @invalid = <!!!! ==== =AAA A=AA AA=A AA==A AAA=AAAA AAAAA AAAAAA A= A== AA= AA== AAA= AAAA AAAAAA=>;
-    @invalid.map: { is-deeply decode-base64($_, :uri), Buf.new(0) }
+    @invalid.map: { is-deeply decode-base64($_, :uri).grep( * > 0 ).elems , 0 }
 }, 'Currupt/invalid encodings';


### PR DESCRIPTION
Base64 strings like "w0OfABDT" where a group of 4 characters is starting by A are not handled correctly.
Problematic part is 

``` perl6
slip($res.grep(* > 0));
```

'A' will create a 00 within the Buf list, which was removed.
An issue here with my fix is that for unvalid valid, instead of returning one Buf(0), it's returnign several Buf(0)
