### PR TITLE
Remove leading 'v' for install error

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,5 @@
 {
-    "perl"        : "v6.0.0",
+    "perl"        : "6.0.0",
     "name"        : "Base64",
     "version"     : "*",
     "owner"       : "ugexe",


### PR DESCRIPTION
I got following error when installing Base64 with panda.

```
% panda install Base64
==> Fetching Base64
Please remove leading 'v' from perl version in Base64's meta info.
Base64 requires Perl version 6.0.0. Cannot continue.
```
