### PR TITLE
Fix Perl version

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,5 @@
 {
-    "perl"        : "6.0.0",
+    "perl"        : "6",
     "name"        : "Base64",
     "version"     : "*",
     "owner"       : "ugexe",


### PR DESCRIPTION
panda does not accept '6.0.0' now and raises error at installing. Sorry #5 fix was not enough.

```
% panda install Base64
==> Fetching Base64
Base64 requires Perl version 6.0.0. Cannot continue.
```
